### PR TITLE
Update extensions_assets_map.json

### DIFF
--- a/VisualStudioDiscordRPC.Shared/Configs/extensions_assets_map.json
+++ b/VisualStudioDiscordRPC.Shared/Configs/extensions_assets_map.json
@@ -46,6 +46,11 @@
       "extensions": [ ".rs", "rlib" ]
     },
     {
+      "name": "Zig",
+      "key": "zig_file",
+      "extensions": [ ".zig", ".zig.zon" ]
+    },
+    {
       "name": "Assembler",
       "key": "asm_file",
       "extensions": [ ".asm" ]

--- a/VisualStudioDiscordRPC.Shared/Configs/extensions_assets_map.json
+++ b/VisualStudioDiscordRPC.Shared/Configs/extensions_assets_map.json
@@ -48,7 +48,7 @@
     {
       "name": "Zig",
       "key": "zig_file",
-      "extensions": [ ".zig", ".zig.zon" ]
+      "extensions": [ ".zig", ".zon" ]
     },
     {
       "name": "Assembler",


### PR DESCRIPTION
+ Zig file support.

<img width="650" height="596" alt="zig_file" src="https://github.com/user-attachments/assets/4a576ce2-a2ed-423e-9bf6-4ca1f9600247" />

(add to the Discord Developer Portal application)