### PR TITLE
Make extension name detection case independent

### DIFF
--- a/VisualStudioDiscordRPC.Shared/Plugs/AssetPlugs/ExtensionIconPlug.cs
+++ b/VisualStudioDiscordRPC.Shared/Plugs/AssetPlugs/ExtensionIconPlug.cs
@@ -1,5 +1,4 @@
 ﻿using EnvDTE;
-using System;
 using System.IO;
 using VisualStudioDiscordRPC.Shared.AssetMap.Interfaces;
 using VisualStudioDiscordRPC.Shared.AssetMap.Models.Assets;

--- a/VisualStudioDiscordRPC.Shared/Plugs/AssetPlugs/ExtensionIconPlug.cs
+++ b/VisualStudioDiscordRPC.Shared/Plugs/AssetPlugs/ExtensionIconPlug.cs
@@ -1,4 +1,5 @@
 ﻿using EnvDTE;
+using System;
 using System.IO;
 using VisualStudioDiscordRPC.Shared.AssetMap.Interfaces;
 using VisualStudioDiscordRPC.Shared.AssetMap.Models.Assets;
@@ -49,7 +50,7 @@ namespace VisualStudioDiscordRPC.Shared.Plugs.AssetPlugs
                 return AssetInfo.Idle;
             }
 
-            string extension = Path.GetExtension(_document.Name);
+            string extension = Path.GetExtension(_document.Name).ToLowerInvariant();
             suitableAsset = _assetMap.GetAsset(asset => asset.Extensions.Contains(extension));
             
             if (suitableAsset == null)


### PR DESCRIPTION
This PR fixes those issues when user works with recognizable file but extension name is written with different cases (for example, .C instead of .c, .ASM instead of .asm, .Cpp instead of .cpp, etc.).

I decided it would be better if plugin got extension names in lower case because existing list already uses them.

Before:
<img width="382" height="152" alt="изображение" src="https://github.com/user-attachments/assets/118d8a2d-4f20-452a-8768-dc5545486be7" />

After:
<img width="353" height="159" alt="изображение" src="https://github.com/user-attachments/assets/e5398851-70a6-4cb3-9a4d-5b13e14ed58c" />

